### PR TITLE
Refactor styling into CSS modules

### DIFF
--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,0 +1,7 @@
+.footer {
+  @apply w-full mt-16 border-t border-white/20 bg-white/5 dark:bg-white/5 backdrop-blur-sm shadow-inner;
+}
+
+.text {
+  @apply text-center py-6 text-xs md:text-sm text-white/60 tracking-widest uppercase font-semibold transition-all duration-300 hover:text-primary-light;
+}

--- a/src/components/Footer.tsx
+++ b/src/components/Footer.tsx
@@ -1,7 +1,9 @@
+import styles from "./Footer.module.css";
+
 const Footer = () => {
   return (
-    <footer className="w-full mt-16 border-t border-white/20 bg-white/5 dark:bg-white/5 backdrop-blur-sm shadow-inner">
-      <div className="text-center py-6 text-xs md:text-sm text-white/60 tracking-widest uppercase font-semibold transition-all duration-300 hover:text-primary-light">
+    <footer className={styles.footer}>
+      <div className={styles.text}>
         © 2025 Humberto López — All Rights Reserved
       </div>
     </footer>

--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -1,0 +1,19 @@
+.navbar {
+  @apply fixed top-0 left-0 w-full z-50 bg-white/10 dark:bg-white/5 backdrop-blur-md border-b border-white/20 shadow-md;
+}
+
+.container {
+  @apply flex justify-between items-center px-6 py-4 max-w-7xl mx-auto;
+}
+
+.title {
+  @apply text-xl font-bold text-white dark:text-primary-light tracking-wide;
+}
+
+.menu {
+  @apply flex gap-6 text-sm md:text-base font-medium text-white/80 dark:text-white/70;
+}
+
+.link {
+  @apply hover:text-purple-400 dark:hover:text-primary-light transition-colors duration-200;
+}

--- a/src/components/Navbar.tsx
+++ b/src/components/Navbar.tsx
@@ -1,17 +1,18 @@
 import { Link } from "react-router-dom";
+import styles from "./Navbar.module.css";
 
 const Navbar = () => {
   return (
-    <nav className="fixed top-0 left-0 w-full z-50 bg-white/10 dark:bg-white/5 backdrop-blur-md border-b border-white/20 shadow-md">
-      <div className="flex justify-between items-center px-6 py-4 max-w-7xl mx-auto">
-        <h1 className="text-xl font-bold text-white dark:text-primary-light tracking-wide">
+    <nav className={styles.navbar}>
+      <div className={styles.container}>
+        <h1 className={styles.title}>
           Humberto Dev
         </h1>
-        <ul className="flex gap-6 text-sm md:text-base font-medium text-white/80 dark:text-white/70">
+        <ul className={styles.menu}>
           <li>
             <Link
               to="/"
-              className="hover:text-purple-400 dark:hover:text-primary-light transition-colors duration-200"
+              className={styles.link}
             >
               Inicio
             </Link>
@@ -19,7 +20,7 @@ const Navbar = () => {
           <li>
             <Link
               to="/projects"
-              className="hover:text-purple-400 dark:hover:text-primary-light transition-colors duration-200"
+              className={styles.link}
             >
               Proyectos
             </Link>
@@ -27,7 +28,7 @@ const Navbar = () => {
           <li>
             <Link
               to="/contact"
-              className="hover:text-purple-400 dark:hover:text-primary-light transition-colors duration-200"
+              className={styles.link}
             >
               Contacto
             </Link>

--- a/src/components/ProjectCard.module.css
+++ b/src/components/ProjectCard.module.css
@@ -1,0 +1,19 @@
+.card {
+  @apply bg-white/10 dark:bg-white/5 p-6 rounded-xl border border-white/20 shadow hover:scale-105 transition;
+}
+
+.image {
+  @apply w-full h-48 object-cover rounded-md mb-4;
+}
+
+.title {
+  @apply text-xl font-semibold text-white dark:text-primary-light;
+}
+
+.description {
+  @apply text-white/70 dark:text-white/60 mb-4;
+}
+
+.link {
+  @apply inline-block mt-2 text-primary-light underline hover:text-white transition;
+}

--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,17 +1,18 @@
 import type { Project } from "../data/projects";
+import styles from "./ProjectCard.module.css";
 
 const ProjectCard = ({ title, description, image, link }: Project) => {
   return (
-    <div className="border rounded-lg p-4 shadow bg-white">
-      {image && <img src={image} alt={title} className="mb-2 rounded" />}
-      <h3 className="font-bold text-lg">{title}</h3>
-      <p>{description}</p>
+    <div className={styles.card}>
+      {image && <img src={image} alt={title} className={styles.image} />}
+      <h3 className={styles.title}>{title}</h3>
+      <p className={styles.description}>{description}</p>
       {link && (
         <a
           href={link}
           target="_blank"
           rel="noopener noreferrer"
-          className="text-blue-500 underline"
+          className={styles.link}
         >
           Ver más
         </a>

--- a/src/components/ThemeToggle.module.css
+++ b/src/components/ThemeToggle.module.css
@@ -1,0 +1,3 @@
+.button {
+  @apply fixed bottom-4 left-4 z-[9999] w-12 h-12 rounded-full bg-white dark:bg-black text-black dark:text-white flex items-center justify-center border border-white/20 shadow-lg hover:scale-110 transition-all;
+}

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,4 +1,5 @@
 import { useTheme } from "../context/ThemeContext";
+import styles from "./ThemeToggle.module.css";
 
 const ThemeToggle = () => {
   const { dark, toggle } = useTheme();
@@ -6,7 +7,7 @@ const ThemeToggle = () => {
   return (
     <button
       onClick={toggle}
-      className="fixed bottom-4 left-4 z-[9999] w-12 h-12 rounded-full bg-white dark:bg-black text-black dark:text-white flex items-center justify-center border border-white/20 shadow-lg hover:scale-110 transition-all"
+      className={styles.button}
       title="Cambiar tema"
     >
       {dark ? "🌙" : "☀️"}

--- a/src/features/Projects/Projects.module.css
+++ b/src/features/Projects/Projects.module.css
@@ -6,23 +6,8 @@
     @apply text-3xl md:text-4xl font-bold text-white dark:text-primary-light mb-10;
   }
   
-  .card {
-    @apply bg-white/10 dark:bg-white/5 p-6 rounded-xl border border-white/20 shadow hover:scale-105 transition;
-  }
-  
-  .image {
-    @apply w-full h-48 object-cover rounded-md mb-4;
-  }
-  
-  .title {
-    @apply text-xl font-semibold text-white dark:text-primary-light;
-  }
-  
-  .description {
-    @apply text-white/70 dark:text-white/60 mb-4;
-  }
-  
-  .link {
-    @apply inline-block mt-2 text-primary-light underline hover:text-white transition;
-  }
+
+.grid {
+  @apply grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8;
+}
   

--- a/src/features/Projects/Projects.tsx
+++ b/src/features/Projects/Projects.tsx
@@ -1,6 +1,7 @@
 import { motion } from "framer-motion";
 import styles from "./Projects.module.css";
 import projects from "../../data/projects";
+import ProjectCard from "../../components/ProjectCard";
 
 const Projects = () => {
   return (
@@ -14,35 +15,16 @@ const Projects = () => {
       >
         Proyectos Destacados
       </motion.h2>
-      <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
+      <div className={styles.grid}>
         {projects.map((project, index) => (
           <motion.div
             key={index}
-            className={styles.card}
             initial={{ opacity: 0, y: 10 }}
             whileInView={{ opacity: 1, y: 0 }}
             transition={{ delay: index * 0.1, duration: 0.4 }}
             viewport={{ once: true }}
           >
-            {project.image && (
-              <img
-                src={project.image}
-                alt={project.title}
-                className={styles.image}
-              />
-            )}
-            <h3 className={styles.title}>{project.title}</h3>
-            <p className={styles.description}>{project.description}</p>
-            {project.link && (
-              <a
-                href={project.link}
-                target="_blank"
-                rel="noopener noreferrer"
-                className={styles.link}
-              >
-                Ver proyecto
-              </a>
-            )}
+            <ProjectCard {...project} />
           </motion.div>
         ))}
       </div>


### PR DESCRIPTION
## Summary
- move inline Tailwind classes to CSS modules
- wrap `ProjectCard` in its own component and reuse in projects page
- add grid style for projects list

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6845c516fedc832aac668b20cb7f4a6c