### PR TITLE
Fix external links in contact page

### DIFF
--- a/src/features/Contact/Contact.tsx
+++ b/src/features/Contact/Contact.tsx
@@ -14,11 +14,21 @@ const Contact = () => {
       <p className={styles.paragraph}>
         También me encuentras en:
         <br />
-        <a href={personalInfo.github} target="_blank" className={styles.link}>
+        <a
+          href={personalInfo.github}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+        >
           GitHub
         </a>{" "}
         |{" "}
-        <a href={personalInfo.linkedin} target="_blank" className={styles.link}>
+        <a
+          href={personalInfo.linkedin}
+          target="_blank"
+          rel="noopener noreferrer"
+          className={styles.link}
+        >
           LinkedIn
         </a>
       </p>


### PR DESCRIPTION
## Summary
- add `rel="noopener noreferrer"` to GitHub and LinkedIn links

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845cbd3b510832a8e0502916b05acb3