### PR TITLE
Add resolver alias for src and refactor imports

### DIFF
--- a/src/components/ProjectCard.tsx
+++ b/src/components/ProjectCard.tsx
@@ -1,4 +1,4 @@
-import type { Project } from "../data/projects";
+import type { Project } from "@/data/projects";
 import styles from "./ProjectCard.module.css";
 
 const ProjectCard = ({ title, description, image, link }: Project) => {

--- a/src/components/ThemeToggle.tsx
+++ b/src/components/ThemeToggle.tsx
@@ -1,4 +1,4 @@
-import { useTheme } from "../context/ThemeContext";
+import { useTheme } from "@/context/ThemeContext";
 import styles from "./ThemeToggle.module.css";
 
 const ThemeToggle = () => {

--- a/src/features/Contact/Contact.tsx
+++ b/src/features/Contact/Contact.tsx
@@ -1,4 +1,4 @@
-import { personalInfo } from "../../data/profile";
+import { personalInfo } from "@/data/profile";
 import styles from "./Contact.module.css";
 
 const Contact = () => {

--- a/src/features/Home/components/AboutSection.tsx
+++ b/src/features/Home/components/AboutSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import styles from "./AboutSection.module.css";
-import { profile } from "../../../data/profile";
+import { profile } from "@/data/profile";
 
 const AboutSection = () => {
   return (

--- a/src/features/Home/components/HeroSection.tsx
+++ b/src/features/Home/components/HeroSection.tsx
@@ -1,6 +1,6 @@
 import { motion } from "framer-motion";
 import styles from "./HeroSection.module.css";
-import { profile } from "../../../data/profile";
+import { profile } from "@/data/profile";
 
 const HeroSection = () => {
   return (

--- a/src/features/Home/components/SkillsSection.tsx
+++ b/src/features/Home/components/SkillsSection.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import styles from "./SkillsSection.module.css";
-import { skills } from "../../../data/skills";
-import type { Skill } from "../../../data/skills";
+import { skills } from "@/data/skills";
+import type { Skill } from "@/data/skills";
 
 // Agrupamos las skills por categoría
 const groupedSkills: { [category: string]: Skill[] } = {};

--- a/src/features/Projects/Projects.tsx
+++ b/src/features/Projects/Projects.tsx
@@ -1,7 +1,7 @@
 import { motion } from "framer-motion";
 import styles from "./Projects.module.css";
-import projects from "../../data/projects";
-import ProjectCard from "../../components/ProjectCard";
+import projects from "@/data/projects";
+import ProjectCard from "@/components/ProjectCard";
 
 const Projects = () => {
   return (

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -1,6 +1,6 @@
-import Navbar from "../components/Navbar";
-import Footer from "../components/Footer";
-import ThemeToggle from "../components/ThemeToggle";
+import Navbar from "@/components/Navbar";
+import Footer from "@/components/Footer";
+import ThemeToggle from "@/components/ThemeToggle";
 import type { ReactNode } from "react";
 
 interface Props {

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -1,7 +1,13 @@
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
+import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  resolve: {
+    alias: {
+      '@': path.resolve(__dirname, 'src'),
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add `@` alias to Vite config
- refactor imports to use `@/` shorthand

## Testing
- `npm run lint` *(fails: Cannot find module '@eslint/js')*
- `npm run build` *(fails: Cannot find module 'react-router-dom' or its corresponding type declarations)*

------
https://chatgpt.com/codex/tasks/task_e_6845cbe1f9e0832abc78a5cca6a0818c