### PR TITLE
Add NotFound page and scroll to top behavior

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,12 +2,14 @@ import { BrowserRouter as Router } from "react-router-dom";
 import { ThemeProvider } from "./context/ThemeContext";
 import AppRoutes from "./routes/AppRoutes";
 import DefaultLayout from "./layouts/DefaultLayout";
+import ScrollToTop from "./components/ScrollToTop";
 import "./index.css";
 
 function App() {
   return (
     <ThemeProvider>
       <Router>
+        <ScrollToTop />
         <DefaultLayout>
           <AppRoutes />
         </DefaultLayout>

--- a/src/components/ScrollToTop.tsx
+++ b/src/components/ScrollToTop.tsx
@@ -1,0 +1,14 @@
+import { useEffect } from "react";
+import { useLocation } from "react-router-dom";
+
+const ScrollToTop = () => {
+  const { pathname } = useLocation();
+
+  useEffect(() => {
+    window.scrollTo(0, 0);
+  }, [pathname]);
+
+  return null;
+};
+
+export default ScrollToTop;

--- a/src/features/NotFound/NotFound.module.css
+++ b/src/features/NotFound/NotFound.module.css
@@ -1,0 +1,11 @@
+.notFound {
+  @apply py-16 px-6 text-center;
+}
+
+.heading {
+  @apply text-3xl md:text-4xl font-bold text-white dark:text-primary-light mb-4;
+}
+
+.text {
+  @apply text-base md:text-lg text-white/80 dark:text-white/60;
+}

--- a/src/features/NotFound/NotFound.tsx
+++ b/src/features/NotFound/NotFound.tsx
@@ -1,0 +1,12 @@
+import styles from "./NotFound.module.css";
+
+const NotFound = () => (
+  <section className={styles.notFound}>
+    <h2 className={styles.heading}>Página no encontrada</h2>
+    <p className={styles.text}>
+      Lo sentimos, la página que buscas no existe.
+    </p>
+  </section>
+);
+
+export default NotFound;

--- a/src/routes/AppRoutes.tsx
+++ b/src/routes/AppRoutes.tsx
@@ -2,12 +2,14 @@ import { Routes, Route } from "react-router-dom";
 import Home from "../features/Home/Home";
 import Contact from "../features/Contact/Contact";
 import Projects from "../features/Projects/Projects";
+import NotFound from "../features/NotFound/NotFound";
 
 const AppRoutes = () => (
   <Routes>
     <Route path="/" element={<Home />} />
     <Route path="/projects" element={<Projects />} />
     <Route path="/contact" element={<Contact />} />
+    <Route path="*" element={<NotFound />} />
   </Routes>
 );
 


### PR DESCRIPTION
## Summary
- add `ScrollToTop` component
- create `NotFound` feature with basic styling
- register catch-all route for NotFound
- enable scroll restoration in `App`

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845cbe70b74832aa958eccf9871cff2