### PR TITLE
Improve light theme readability

### DIFF
--- a/src/components/Footer.module.css
+++ b/src/components/Footer.module.css
@@ -1,7 +1,7 @@
 .footer {
-  @apply w-full mt-16 border-t border-white/20 bg-white/5 dark:bg-white/5 backdrop-blur-sm shadow-inner;
+  @apply w-full mt-16 bg-pixel-light/20 dark:bg-pixel-soft/80 border-t border-pixel-dark/40 dark:border-pixel backdrop-blur-sm shadow-inner;
 }
 
 .text {
-  @apply text-center py-6 text-xs md:text-sm text-white/60 tracking-widest uppercase font-semibold transition-all duration-300 hover:text-pixel-light;
+  @apply text-center py-6 text-xs md:text-sm text-pixel-dark/60 dark:text-pixel-light/60 tracking-widest uppercase font-semibold transition-all duration-300 hover:text-pixel-light;
 }

--- a/src/components/Navbar.module.css
+++ b/src/components/Navbar.module.css
@@ -1,5 +1,5 @@
 .navbar {
-  @apply fixed top-0 left-0 w-full z-50 bg-white/10 dark:bg-white/5 backdrop-blur-md border-b border-white/20 shadow-md;
+  @apply fixed top-0 left-0 w-full z-50 bg-pixel-light/30 dark:bg-pixel-soft/80 backdrop-blur-md border-b border-pixel-dark/40 dark:border-pixel shadow-md;
 }
 
 .container {
@@ -7,13 +7,13 @@
 }
 
 .title {
-  @apply text-xl font-bold text-white dark:text-pixel-light tracking-wide;
+  @apply text-xl font-bold text-pixel-dark dark:text-pixel-light tracking-wide;
 }
 
 .menu {
-  @apply flex gap-6 text-sm md:text-base font-medium text-white/80 dark:text-white/70;
+  @apply flex gap-6 text-sm md:text-base font-medium text-pixel-dark/80 dark:text-pixel-light/70;
 }
 
 .link {
-  @apply hover:text-pixel-light dark:hover:text-pixel-light transition-colors duration-200;
+  @apply text-pixel-dark hover:text-pixel dark:text-pixel-light dark:hover:text-pixel-light transition-colors duration-200;
 }

--- a/src/components/ProjectCard.module.css
+++ b/src/components/ProjectCard.module.css
@@ -1,5 +1,5 @@
 .card {
-  @apply bg-white/10 dark:bg-white/5 p-6 rounded-xl border border-white/20 shadow hover:scale-105 transition;
+  @apply bg-pixel-light/20 dark:bg-pixel-soft/50 p-6 rounded-xl border border-pixel-dark/40 dark:border-pixel shadow hover:scale-105 transition;
 }
 
 .image {
@@ -7,13 +7,13 @@
 }
 
 .title {
-  @apply text-xl font-semibold text-white dark:text-pixel-light;
+  @apply text-xl font-semibold text-pixel-dark dark:text-pixel-light;
 }
 
 .description {
-  @apply text-white/70 dark:text-white/60 mb-4;
+  @apply text-pixel-dark/80 dark:text-pixel-light/60 mb-4;
 }
 
 .link {
-  @apply inline-block mt-2 text-pixel-light underline hover:text-white transition;
+  @apply inline-block mt-2 text-pixel-dark underline hover:text-pixel transition;
 }

--- a/src/features/Contact/Contact.module.css
+++ b/src/features/Contact/Contact.module.css
@@ -3,14 +3,14 @@
   }
   
   .heading {
-    @apply text-3xl md:text-4xl font-bold text-white dark:text-pixel-light mb-4;
+    @apply text-3xl md:text-4xl font-bold text-pixel-dark dark:text-pixel-light mb-4;
   }
   
   .paragraph {
-    @apply text-base md:text-lg text-white/80 dark:text-white/60 mb-4;
+    @apply text-base md:text-lg text-pixel-dark/80 dark:text-pixel-light/60 mb-4;
   }
   
   .link {
-    @apply text-pixel-light underline hover:text-white transition;
+    @apply text-pixel-dark underline hover:text-pixel transition;
   }
   

--- a/src/features/NotFound/NotFound.module.css
+++ b/src/features/NotFound/NotFound.module.css
@@ -3,9 +3,9 @@
 }
 
 .heading {
-  @apply text-3xl md:text-4xl font-bold text-white dark:text-pixel-light mb-4;
+  @apply text-3xl md:text-4xl font-bold text-pixel-dark dark:text-pixel-light mb-4;
 }
 
 .text {
-  @apply text-base md:text-lg text-white/80 dark:text-white/60;
+  @apply text-base md:text-lg text-pixel-dark/80 dark:text-pixel-light/60;
 }

--- a/src/features/Projects/Projects.module.css
+++ b/src/features/Projects/Projects.module.css
@@ -3,7 +3,7 @@
   }
   
   .heading {
-    @apply text-3xl md:text-4xl font-bold text-white dark:text-pixel-light mb-10;
+    @apply text-3xl md:text-4xl font-bold text-pixel-dark dark:text-pixel-light mb-10;
   }
   
 

--- a/src/layouts/DefaultLayout.tsx
+++ b/src/layouts/DefaultLayout.tsx
@@ -8,7 +8,7 @@ interface Props {
 }
 
 const DefaultLayout = ({ children }: Props) => (
-  <div className="min-h-screen flex flex-col bg-grid-light dark:bg-grid-dark font-pixel text-gray-900 dark:text-gray-200">
+  <div className="min-h-screen flex flex-col bg-grid-light dark:bg-grid-dark font-pixel text-pixel-dark dark:text-pixel-light">
     <ThemeToggle />
     <Navbar />
     <main className="flex-grow p-6 flex items-center justify-center">


### PR DESCRIPTION
## Summary
- unify text colors for light/dark themes
- restyle navbar, footer, and project cards with pixel palette
- adjust contact, not-found and projects headings
- set default text colors in layout

## Testing
- `npm run lint` *(fails: Cannot find package '@eslint/js')*

------
https://chatgpt.com/codex/tasks/task_e_6845dac42c84832a971fb9551502a054